### PR TITLE
Dynamically link HIE for great TH speedup

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -50,7 +50,7 @@ For a specific set of GHC versions (note: The ~hie~ / ~hie-wrapper~ binaries wil
    }
 #+END_SRC
 
-For *all* supported GHC versions (warning: requires ~20GB of space for all 9 versions):
+For *all* supported GHC versions (warning: requires ~30GB (or <10GB with compression) of space for all 9 versions):
 #+BEGIN_SRC nix
   {
     environment.systemPackages = [
@@ -75,7 +75,7 @@ For a specific set of GHC versions (note: The ~hie~ / ~hie-wrapper~ binaries wil
   nix-env -iA selection --arg selector 'p: { inherit (p) ghc864 ghc863 ghc843; }' -f https://github.com/infinisil/all-hies/tarball/master
 #+END_SRC
 
-For *all* supported GHC versions (warning: requires ~20GB of space for all 9 versions):
+For *all* supported GHC versions (warning: requires ~30GB (or <10GB with compression) of space for all 9 versions):
 #+BEGIN_SRC bash
   nix-env -iA selection --arg selector 'p: p' -f https://github.com/infinisil/all-hies/tarball/master
 #+END_SRC

--- a/default.nix
+++ b/default.nix
@@ -67,6 +67,15 @@ let
         # Embed the ghc version into the name
         pname = "${old.pname}-${ghcVersion}";
         version = lib.substring 0 8 revision;
+
+        # Link Haskell libraries dynamically, improves startup time for projects
+        # using TH by a lot (40x faster in one of my tests), but also Increases
+        # closure size by about 50% (=~ 1.2GB) per HIE version
+        # Can be disabled again for GHC versions that have a fix for
+        # https://gitlab.haskell.org/ghc/ghc/issues/15524
+        enableSharedExecutables = true;
+        isLibrary = false;
+        doHaddock = false;
       })).overrideAttrs (old: {
         nativeBuildInputs = old.nativeBuildInputs or [] ++ [ pkgs.makeWrapper ];
         # Make sure hie-x.x.x binary exists
@@ -98,9 +107,7 @@ let
       pkgs = forGhc.pkgs;
     };
 
-    build = hlib.justStaticExecutables
-      (expr.override overrideFun).haskell-ide-engine;
-
+    build = (expr.override overrideFun).haskell-ide-engine;
   in build;
 
   # A set of all ghc versions for all hie versions, like


### PR DESCRIPTION
See https://github.com/domenkozar/hie-nix/issues/59

Thanks to @mpickering for pointing this out

This will increase closure size by about 50% for each HIE version, but I think this is alright because 4 minute startup time for HIE is unacceptable (which is the startup time for [nixbot](https://github.com/infinisil/nixbot) if I use TemplateHaskell). It's ~4 seconds with this change.

Will merge once the Linux builds are complete and pushed to all-hies cachix.