### PR TITLE
Haskell overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -186,7 +186,8 @@ let
     latest = lib.last (lib.attrValues versions);
   };
 
-in mkSet allVersions.stable
+in mkSet allVersions.stable //
+{ version = builtins.readFile ./generated/stable/stack2nix/revision; }
 // lib.mapAttrs (_: mkSet) (builtins.removeAttrs allVersions ["stable"])
 // {
   # Stable, but fall back to unstable if stable doesn't have a certain GHC

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,39 @@
+# This overlay adds a haskell-ide-engine package to all Haskell package sets
+# that have a supported GHC version.
+
+# In the future arguments like `withUnstable` or so might be added
+{}:
+
+self: super:
+
+let
+
+  inherit (super) lib;
+
+  all-hies = import ./. {};
+
+  hieOverride = name: old: {
+    overrides = lib.composeExtensions (old.overrides or (hself: hsuper: {})) (hself: hsuper: {
+      haskell-ide-engine = all-hies.versions.${name} or (throw
+        ( "haskell-ide-engine stable version ${all-hies.version} doesn't have "
+        + "support for GHC version ${name}. "
+        + "Supported versions are ${toString (lib.attrNames all-hies.versions)}."));
+    });
+  };
+
+in {
+
+  # Needed for the foreseeable future until everybody has
+  # https://github.com/NixOS/nixpkgs/pull/62742
+  haskellPackages = super.haskellPackages.override (old:
+  let
+    split = builtins.splitVersion (builtins.parseDrvName old.ghc.name).version;
+    name = "ghc${lib.elemAt split 0}${lib.elemAt split 1}${lib.elemAt split 2}";
+  in hieOverride name old);
+
+  haskell = super.haskell // {
+    packages = super.lib.mapAttrs (name: packages:
+      packages.override (hieOverride name)
+    ) super.haskell.packages;
+  };
+}


### PR DESCRIPTION
An overlay that adds a haskell-ide-engine package to all Haskell package sets in nixpkgs. This should allow for easy project integration.

Closes #6 

TODO
- [ ] Think about how this integrates with the average Haskell Nix project (`shellFor`)
- [ ] Update readme with this info, optimally showing how you can get a project-local HIE