### PR TITLE
Clarify that enabling cache isnt the end of it

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -15,6 +15,7 @@ cachix use all-hies
 #+END_SRC
 
 Note: Due to an issue with cachix you might have to restart the nix daemon for this to take effect, refer to [[https://github.com/cachix/cachix/issues/188][this issue]].
+After configuring cache, proceed to install instructions for your system.
 
 *** Building without cached builds
 

--- a/Readme.org
+++ b/Readme.org
@@ -16,7 +16,7 @@ cachix use all-hies
 
 Note: Due to an issue with cachix you might have to restart the nix daemon for this to take effect, refer to [[https://github.com/cachix/cachix/issues/188][this issue]].
 
-After configuring cache, proceed to install instructions for your system.
+After configuring the cache, proceed to the install instructions below.
 
 *** Building without cached builds
 

--- a/Readme.org
+++ b/Readme.org
@@ -15,6 +15,7 @@ cachix use all-hies
 #+END_SRC
 
 Note: Due to an issue with cachix you might have to restart the nix daemon for this to take effect, refer to [[https://github.com/cachix/cachix/issues/188][this issue]].
+
 After configuring cache, proceed to install instructions for your system.
 
 *** Building without cached builds


### PR DESCRIPTION
I got the impression that the part with enabling cache was the tldr solution, given that the next section is the part for installing without it proceeded for bunch of other instructions giving me the impression that the install instructions refer to non cached option.