### PR TITLE
Sort ghc versions before building

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,8 +7,9 @@ import           Control.Monad.Reader
 import           Data.Aeson                 (decode)
 import qualified Data.ByteString.Lazy.Char8 as BS
 import           Data.Char                  (isDigit, isHexDigit)
-import           Data.List                  (intercalate, isPrefixOf)
+import           Data.List                  (intercalate, isPrefixOf, sortOn)
 import           Data.Maybe
+import           Data.Ord                   (Down(..))
 import           Data.Time
 import           Distribution.System        (Arch (..), OS (..), Platform (..))
 import           Network.HTTP.Client
@@ -215,7 +216,7 @@ regenerate root revision = do
   liftIO $ putStrLn $ "Writing " ++ revName ++ " to " ++ root ++ "stack2nix/revision"
   liftIO $ writeFile (root </> "stack2nix/revision") revName
   files <- listRepoFiles hieRepo
-  let versions = mapMaybe (stackPathRegex `match`) files
+  let versions = sortOn Down (mapMaybe (stackPathRegex `match`) files)
   liftIO $ putStrLn $ "HIE " ++ revName ++ " has ghc versions " ++ intercalate ", " (map show versions)
   forM_ versions $ \version -> do
     contents <- genS2N root hash version


### PR DESCRIPTION
Most recent versions first.

Assuming that the more recent versions are more desirable this allow one to start building the updated hie from the new configuratoins earlier