### PR TITLE
Use compiler-nix-name instead of (in addition to) ghc.version

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -31,7 +31,11 @@ in final: prev: {
           then "glibc-2.30"
           else final.glibc.name;
         inherit sources;
-        ghcVersion = args.ghc.version;
+        # compiler-nix-name is of the form 'ghc883'
+        ghcVersion = if args ? compiler-nix-name then
+          builtins.concatStringsSep "."
+            (builtins.match "ghc([0-9])([0-9])([0-9])" args.compiler-nix-name)
+                     else args.ghc.version; # deprecated
       }).combined;
     };
   };

--- a/overlay.nix
+++ b/overlay.nix
@@ -32,9 +32,8 @@ in final: prev: {
           else final.glibc.name;
         inherit sources;
         # compiler-nix-name is of the form 'ghc883'
-        ghcVersion = if args ? compiler-nix-name then
-          builtins.concatStringsSep "."
-            (builtins.match "ghc([0-9])([0-9])([0-9])" args.compiler-nix-name)
+        ghcVersion = if args ? compiler-nix-name
+                     then final.haskell-nix.compiler.${args.compiler-nix-name}.version
                      else args.ghc.version; # deprecated
       }).combined;
     };


### PR DESCRIPTION
The `ghc` argument to *project in haskell.nix is deprecated.